### PR TITLE
Add "strict_min_version": "60.0"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,8 @@
     ],
     "applications": {
         "gecko": {
-            "id": "scrapbee@scrapbee.org"
+            "id": "scrapbee@scrapbee.org",
+            "strict_min_version": "60.0"
         }
     },
     "sidebar_action": {


### PR DESCRIPTION
The project has used https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import, it is enabled by default in Firefox 60.