### PR TITLE
Force fonts of actions menu

### DIFF
--- a/popup/browser_action.html
+++ b/popup/browser_action.html
@@ -28,6 +28,8 @@
        /* display:flex; */
        /* justify-content: flex-start; */
        /* flex-wrap: nowrap; */
+       font-family: Arial, Helvetica, sans-serif;
+       font-size: 12px;
        text-align:left;
        vertical-align:middle;
        line-height:30px;


### PR DESCRIPTION
Choose appropriate fonts for the actions menu, in case the user's settings are too big, causing Scrapbee menu to be mangled (fixes https://github.com/vctfence/scrapbee/issues/87)

The Scrapbee actions menu would have a similar font size as other extension (Tampermonkey, Greasemonkey) or as the right click menu.