### PR TITLE
Auto-close popup menu in sidebar

### DIFF
--- a/js/control.js
+++ b/js/control.js
@@ -108,6 +108,9 @@ class ContextMenu{
     }
     bindEvents(){
         var self = this;
+        $(document.body).bind("mouseleave", function(e) {
+            self.$menu.hide();
+        });
         $(document.body).bind("mousedown", function(e){
             var click_menu = $(e.target).closest(self.$menu).length > 0;
             if(click_menu && $(e.target).hasClass("simple-menu-item")){


### PR DESCRIPTION
Allow the popup menu in sidebar to disappear when the mouse leaves it (fixes https://github.com/vctfence/scrapbee/issues/92 ).

Sorry, not tested as the extension doesn't succeed to launch the backend in debugging mode.
